### PR TITLE
Fix the check condition when only --config is specified

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -30,7 +30,7 @@ co(function* () {
     }),
     flags = cli.flags
 
-  if (!flags.recipe && !flags.config) flags.recipe = 'minimal'
+  if (!flags.recipe && !flags.config && flags.config !== '') flags.recipe = 'minimal'
 
   if (flags.recipe) {
     const pkgName = 'felt-recipe-' + flags.recipe


### PR DESCRIPTION
When only `--config` is specified,
```
$ felt --config
```
not only the default config file `felt.config.js`, the recipe `felt-recipe-minimal` is always used too.

So, I changed the check condition to use only `felt.config.js`.
Is this change correct ?
